### PR TITLE
feat: improve meta typings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+trim_trailing_whitespace = true
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.lintstagedrc.js
+++ b/.lintstagedrc.js
@@ -3,4 +3,7 @@ module.exports = {
     'prettier --write',
     'eslint --fix'
   ],
+  '*.md': [
+    'prettier --write',
+  ],
 };

--- a/README.md
+++ b/README.md
@@ -1,28 +1,51 @@
 # zod-metadata
+
 Metadata support for [Zod](https://www.npmjs.com/package/zod) schemas.
 
-## Install
+## Installation
+
 ```bash
 npm install zod-metadata
+yarn add zod-metadata
+pnpn add zod-metadata
 ```
 
-## Register the Zod extension
+## Basic Usage
+
+```typescript
+import 'zod-metadata/register';
+import { z } from 'zod';
+
+const schema = z.string().meta({
+  example: 'John',
+  number: 42,
+});
+
+schema.getMeta(); // => { example: 'John', number: 42 }
+```
+
+## Registration
 
 ### Automatic
+
 Import `zod-metadata/register` at the top of your entry files:
 
 **JavaScript**
+
 ```javascript
 require('zod-metadata/register');
 ```
 
 **TypeScript**
+
 ```typescript
 import 'zod-metadata/register';
 ```
 
 ### Manual
+
 **JavaScript**
+
 ```javascript
 const { register } = require('zod-metadata');
 const zod = require('zod');
@@ -31,6 +54,7 @@ register(zod);
 ```
 
 **TypeScript**
+
 ```typescript
 import { register } from 'zod-metadata';
 import zod from 'zod';
@@ -39,7 +63,9 @@ register(zod);
 ```
 
 ### Preload
+
 **JavaScript**
+
 ```bash
 node -r zod-metadata/register my-script.js
 ```
@@ -50,6 +76,7 @@ require('zod-metadata'); // make type declarations available
 ```
 
 **TypeScript**
+
 ```bash
 ts-node -r zod-metadata/register my-script.js
 ```
@@ -57,23 +84,4 @@ ts-node -r zod-metadata/register my-script.js
 ```typescript
 // my-script.ts
 import {} from 'zod-metadata'; // make type declarations available
-```
-
-## API
-The API provides two methods that will read and write to `schema._def.meta`.
-
-### `schema.meta(meta: Record<string, unknown>): this`
-Accumulates metadata mutating the schema:
-
-```javascript
-schema
-  .meta({ key1: value1 })
-  .meta({ key2: value2 });
-```
-
-### `schema.getMeta(): Record<string, unknown>`
-Returns the metadata:
-
-```javascript
-schema.getMeta(); // => { key1: value1, key2: value2 }
 ```

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "scripts": {
     "clean": "rimraf dist",
     "build": "npm run clean && tsc -p tsconfig.build.json",
-    "format": "prettier \"**/*.[jt]s\" --write",
+    "format": "prettier \"**/*.{js,ts,md}\" --write",
     "lint": "eslint . --ext .ts --fix",
     "test": "jest",
     "test:cov": "jest --coverage",


### PR DESCRIPTION
An attempt to solve #1 

- [x] make the schema's meta a type param
- [x] fix `getMeta()` return type missing `undefined`
- [x] add `.editorconfig`
- [x] format markdown via `prettier`  