### PR TITLE
Allow overriding default .meta() and .getMeta() data types.

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,8 @@ Accumulates metadata mutating the schema:
 
 ```javascript
 schema
-  .meta({ key1: value1 })
-  .meta({ key2: value2 });
+    .meta({ key1: value1 })
+    .meta({ key2: value2 });
 ```
 
 ### `schema.getMeta(): Record<string, unknown>`
@@ -76,4 +76,26 @@ Returns the metadata:
 
 ```javascript
 schema.getMeta(); // => { key1: value1, key2: value2 }
+```
+
+## Typings
+
+To define global (default) typings for `.meta()` and `.getMeta()` calls (and so get autocompletion in your IDE), create a `<some-name>.d.ts` file in your project and override default IMeta interface, like this:
+
+```typescript
+import z from 'zod';
+
+declare module 'zod' {
+    interface IMeta {
+        name: string;
+        age?: number;
+    }
+}
+```
+
+To override default return type of a single `.getMeta()` call or define argument type of a single `.meta()` call, use optional generic arguments, like:
+
+```typescript
+z.string().getMeta<{city: string}>({city: 'New York'});
+const city = z.string().meta<{city: string}>().city;
 ```

--- a/README.md
+++ b/README.md
@@ -67,8 +67,8 @@ Accumulates metadata mutating the schema:
 
 ```javascript
 schema
-    .meta({ key1: value1 })
-    .meta({ key2: value2 });
+  .meta({ key1: value1 })
+  .meta({ key2: value2 });
 ```
 
 ### `schema.getMeta(): Record<string, unknown>`
@@ -96,6 +96,6 @@ declare module 'zod' {
 To override default return type of a single `.getMeta()` call or define argument type of a single `.meta()` call, use optional generic arguments, like:
 
 ```typescript
-z.string().getMeta<{city: string}>({city: 'New York'});
-const city = z.string().meta<{city: string}>().city;
+z.string().meta<{city: string}>({city: 'New York'});
+const city = z.string().getMeta<{city: string}>().city;
 ```

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,8 +10,8 @@ declare module 'zod' {
   }
 
   interface ZodType {
-    getMeta<T = IMeta>(): T;
-    meta<T = IMeta>(meta: T): this;
+    getMeta<T extends object = IMeta>(): T;
+    meta<T extends object = IMeta>(meta: T): this;
   }
 }
 
@@ -20,7 +20,7 @@ export function register(zod: typeof z) {
     return;
   }
 
-  zod.ZodType.prototype.meta = function (meta: Record<string, unknown>) {
+  zod.ZodType.prototype.meta = function (meta: object) {
     this._def.meta = { ...this._def.meta, ...meta };
     return this;
   };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,13 +1,17 @@
 import z from 'zod';
 
 declare module 'zod' {
+  interface IMeta {
+    [k: string]: unknown;
+  }
+
   interface ZodTypeDef {
-    meta?: Record<string, unknown>;
+    meta?: IMeta;
   }
 
   interface ZodType {
-    getMeta(): Record<string, unknown>;
-    meta(meta: Record<string, unknown>): this;
+    getMeta<T = IMeta>(): T;
+    meta<T = IMeta>(meta: T): this;
   }
 }
 


### PR DESCRIPTION
Hello, Emil! Please consider approach that allows to define default metadata interface and also allows to override `.meta()` argument type and `.getMeta()` return type by using generics!